### PR TITLE
Temp fix for xmllint not parsing backslashes correctly

### DIFF
--- a/lib/DBSteward/xml_parser.php
+++ b/lib/DBSteward/xml_parser.php
@@ -755,7 +755,11 @@ class xml_parser {
     if (file_put_contents($tmp_file, $xml) === FALSE) {
       throw new exception("Failed to write to temporary validation file: " . $tmp_file);
     }
-    dbsteward::cmd("xmllint --noout --dtdvalid " . $dtd_file . " " . $tmp_file . " 2>&1");
+    // There is a quirk / bug in libxml2-2.7.8 for Windows that prevents xmllint from recognizing
+    // backslash characters as valid path separators.  An easy work-around is to just use
+    // forward slash everywhere since Windows and xmllint both agree on these.
+    dbsteward::cmd("xmllint --noout --dtdvalid " . str_replace('\\', '/', $dtd_file) . " " . $tmp_file . " 2>&1");
+    // dbsteward::cmd("xmllint --noout --dtdvalid " . $dtd_file . " " . $tmp_file . " 2>&1");
     if ($echo_status) {
       dbsteward::info("XML Validates (size = " . strlen($xml) . ") against $dtd_file OK");
     }


### PR DESCRIPTION
Fix for #130 

Forward slashes are recognized on most if not all platforms we are targeting.  Just replace the --dtdvalid path's backslashes with forward slashes and call it a day.

I did some poking around at this to see if there were any edge cases.  The only obvious case to me is the scenario where a UNIX path name contains a backslash.  However, in my testing on Windows 10 WSL it doesn't appear that xmllint bundled with libxml version 20901 handles backslashes in DTD paths as expected either.

For example:
```
# File's there
ls -l /home/bstoots/foo\\bar/dbsteward.dtd
-rwxrwxrwx 1 bstoots bstoots 10197 Sep 12 21:05 /home/bstoots/foo\bar/dbsteward.dtd

# But yet:
xmllint --noout --dtdvalid /home/bstoots/foo\\bar/dbsteward.dtd /tmp/dbsteward_validate_oIHEV0 2>&1 ; echo $?
Could not parse DTD /home/bstoots/foo\bar/dbsteward.dtd
2

# No dice on ghoulish overkill of escaping either
xmllint --noout --dtdvalid /home/bstoots/foo\\\\bar/dbsteward.dtd /tmp/dbsteward_validate_oIHEV0 2>&1 ; echo $?
Could not parse DTD /home/bstoots/foo\\bar/dbsteward.dtd
2
```