### PR TITLE
fix for #136 Table ordering not properly calculated when using foreignKey element

### DIFF
--- a/lib/DBSteward/xml_parser.php
+++ b/lib/DBSteward/xml_parser.php
@@ -872,6 +872,7 @@ class xml_parser {
         }
       }
     }
+
     // does b contain a column that a constraints against?
     $constraints = $a['table']->xpath('constraint');
     foreach ($constraints AS $constraint) {
@@ -888,6 +889,20 @@ class xml_parser {
               return TRUE;
             }
           }
+        }
+      }
+    }
+      
+    // does b contain a column that a has a foreign key on?
+    $foreignKeys = $a['table']->xpath('foreignKey');
+    foreach ($foreignKeys AS $foreignKey) {
+      // talking about the same schema?
+      if (strlen($foreignKey['foreignSchema']) === 0 || strcasecmp($foreignKey['foreignSchema'], $b['schema']['name']) == 0) {
+        // talking about the same table?
+        if (strcasecmp($foreignKey['foreignTable'], $b['table']['name']) == 0) {
+          // so yes, a has a dependency on b via foreign key definition
+          dbsteward::debug($a['schema']['name'] . '.' . $a['table']['name'] . '.' . $foreignKey['name'] . "\thas foreignKey dep on\t" . $b['schema']['name'] . '.' . $b['table']['name']);
+          return TRUE;
         }
       }
     }

--- a/tests/tableHasDependencyTest.php
+++ b/tests/tableHasDependencyTest.php
@@ -18,7 +18,7 @@ class tableHasDependencyTest extends PHPUnit_Framework_TestCase {
    * confirm that table dependencies are detected through inheritsSchema on the table element
    * 
    * @group nodb
-   * @group psql8
+   * @group pgsql8
    * @group mysql5
    */
   public function testDependencyOfChildViaInheritsSchema() {
@@ -45,7 +45,7 @@ class tableHasDependencyTest extends PHPUnit_Framework_TestCase {
    * confirm that table dependencies are detected through foreignSchema/foreignTable/foreignColumn inline in column element
    * 
    * @group nodb
-   * @group psql8
+   * @group pgsql8
    * @group mysql5
    */
   public function testDependencyOfChildViaColumnInlineForeignKey() {
@@ -74,7 +74,7 @@ class tableHasDependencyTest extends PHPUnit_Framework_TestCase {
    * confirm that table dependencies are detected through foreignKey elements
    * 
    * @group nodb
-   * @group psql8
+   * @group pgsql8
    * @group mysql5
    */
   public function testDependencyOfChildViaForeignKey() {

--- a/tests/tableHasDependencyTest.php
+++ b/tests/tableHasDependencyTest.php
@@ -14,6 +14,13 @@ require_once __DIR__ . '/dbstewardUnitTestBase.php';
 
 class tableHasDependencyTest extends PHPUnit_Framework_TestCase {
 
+  /**
+   * confirm that table dependencies are detected through inheritsSchema on the table element
+   * 
+   * @group nodb
+   * @group psql8
+   * @group mysql5
+   */
   public function testDependencyOfChildViaInheritsSchema() {
     $parent = '<schema name="parentSchema" />';
     $parent_table = '
@@ -33,7 +40,14 @@ class tableHasDependencyTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue(xml_parser::table_has_dependency($child_obj, $parent_obj));
     $this->assertFalse(xml_parser::table_has_dependency($parent_obj, $child_obj));
   }
-
+  
+  /**
+   * confirm that table dependencies are detected through foreignSchema/foreignTable/foreignColumn inline in column element
+   * 
+   * @group nodb
+   * @group psql8
+   * @group mysql5
+   */
   public function testDependencyOfChildViaColumnInlineForeignKey() {
     $parent = '<schema name="parentSchema" />';
     $parent_table = '
@@ -56,6 +70,13 @@ class tableHasDependencyTest extends PHPUnit_Framework_TestCase {
     $this->assertFalse(xml_parser::table_has_dependency($parent_obj, $child_obj));
   }
 
+  /**
+   * confirm that table dependencies are detected through foreignKey elements
+   * 
+   * @group nodb
+   * @group psql8
+   * @group mysql5
+   */
   public function testDependencyOfChildViaForeignKey() {
     $parent = '<schema name="parentSchema" />';
     $parent_table = '

--- a/tests/tableHasDependencyTest.php
+++ b/tests/tableHasDependencyTest.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/dbstewardUnitTestBase.php';
 
 class tableHasDependencyTest extends PHPUnit_Framework_TestCase {
 
-  public function testDependencyOfChild() {
+  public function testDependencyOfChildViaInheritsSchema() {
     $parent = '<schema name="parentSchema" />';
     $parent_table = '
         <table name="parentTable">
@@ -23,6 +23,60 @@ class tableHasDependencyTest extends PHPUnit_Framework_TestCase {
     $child = '<schema name="childSchema" />';
     $child_table = '
         <table name="childTable" inheritsSchema="parentSchema" inheritsTable="parentTable">
+        </table>';
+
+    $parent_obj = array('schema' => simplexml_load_string($parent),
+                        'table' => simplexml_load_string($parent_table));
+    $child_obj = array('schema' => simplexml_load_string($child),
+                       'table' => simplexml_load_string($child_table));
+
+    $this->assertTrue(xml_parser::table_has_dependency($child_obj, $parent_obj));
+    $this->assertFalse(xml_parser::table_has_dependency($parent_obj, $child_obj));
+  }
+
+  public function testDependencyOfChildViaColumnInlineForeignKey() {
+    $parent = '<schema name="parentSchema" />';
+    $parent_table = '
+        <table name="parentTable">
+          <column name="parentColumn" type="integer"/>
+        </table>';
+
+    $child = '<schema name="parentSchema" />';
+    $child_table = '
+        <table name="childTable">
+          <column name="childColumn" foreignSchema="parentSchema" foreignTable="parentTable" foreignColumn="parentColumn"/>
+        </table>';
+
+    $parent_obj = array('schema' => simplexml_load_string($parent),
+                        'table' => simplexml_load_string($parent_table));
+    $child_obj = array('schema' => simplexml_load_string($child),
+                       'table' => simplexml_load_string($child_table));
+
+    $this->assertTrue(xml_parser::table_has_dependency($child_obj, $parent_obj));
+    $this->assertFalse(xml_parser::table_has_dependency($parent_obj, $child_obj));
+  }
+
+  public function testDependencyOfChildViaForeignKey() {
+    $parent = '<schema name="parentSchema" />';
+    $parent_table = '
+        <table name="parentTable">
+          <column name="parentColumn1" type="integer"/>
+          <column name="parentColumn2" type="integer"/>
+        </table>';
+
+    $child = '<schema name="parentSchema" />';
+    $child_table = '
+        <table name="childTable">
+          <column name="childColumn1" type="integer"/>
+          <column name="childColumn2" type="integer"/>
+          <foreignKey 
+            columns="childColumn1, childColumn2"
+            foreignSchema="parentSchema"
+            foreignTable="parentTable"
+            foreignColumns="parentColumn1, parentColumn2"
+            constraintName="multi_column_foreign_key"
+            onDelete="CASCADE"
+          />
         </table>';
 
     $parent_obj = array('schema' => simplexml_load_string($parent),


### PR DESCRIPTION
- add check on foreignKey elements when determining if a table has a dependency on another table
- add test cases to check table dependencies via column element inline foreign key and foreign key elements